### PR TITLE
Remove unused `config.h` header from umbrella header directory

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=14.4,name=iPhone 12']
+        destination: ['platform=iOS Simulator,OS=15.2,name=iPhone 12']
     steps:
       - uses: actions/checkout@v2
         with:
@@ -32,7 +32,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        destination: ['platform=tvOS Simulator,OS=14.3,name=Apple TV']
+        destination: ['platform=tvOS Simulator,OS=15.2,name=Apple TV']
     steps:
       - uses: actions/checkout@v2
         with:

--- a/include/AblyDeltaCodec/config.h
+++ b/include/AblyDeltaCodec/config.h
@@ -1,1 +1,0 @@
-../../source/config.h


### PR DESCRIPTION
This fixes a warning that some users were seeing when importing this library as a transitive dependency of ably-cocoa. See commit message for more details.

(I also had to tweak some CI config because it's been so long since we last ran a CI job in this repo.)

Closes #15.