### PR TITLE
Link SPM target to Foundation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=18.2,name=iPhone 16']
+        destination: ['platform=iOS Simulator,OS=26.0.1,name=iPhone 17']
     steps:
       - uses: actions/checkout@v2
         with:

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,9 @@ let package = Package(
             	.headerSearchPath("source"),
                 .headerSearchPath("xdelta/xdelta3"),
                 .define("HAVE_DELTA_CONFIG_H", to: "1"),
+            ],
+            linkerSettings: [
+                .linkedFramework("Foundation")
             ]
         )
     ],


### PR DESCRIPTION
A customer reported in https://github.com/ably/ably-cocoa/issues/2137 that they're getting "Undefined symbol" linker errors for things like `_objc_retain` and other basic things that should come from Foundation. I wasn't able to reproduce (the circumstances must be quite specific) but they confirmed that this change fixes the issue for them.