### PR TITLE
ci: GitHub Actions workflow security cleanup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,12 +1,16 @@
 on:
   pull_request:
   push:
-    branches:    
+    branches:
       - main
+
+permissions: {}
 
 jobs:
   macOS:
     runs-on: macOS-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
         with:
@@ -17,6 +21,8 @@ jobs:
 
   iOS:
     runs-on: macOS-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         destination: ['platform=iOS Simulator,OS=26.0.1,name=iPhone 17']
@@ -32,6 +38,8 @@ jobs:
 
   tvOS:
     runs-on: macOS-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         destination: ['platform=tvOS Simulator,OS=18.2,name=Apple TV']

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+          persist-credentials: false
       - name: Build and Test
         run: xcodebuild clean test -project DeltaCodec.xcodeproj -scheme DeltaCodec-macOS CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 
@@ -23,6 +24,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+          persist-credentials: false
       - name: Build and Test
         run: xcodebuild clean test -project DeltaCodec.xcodeproj -scheme DeltaCodec-iOS -destination "${destination}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
     env:
@@ -37,6 +39,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+          persist-credentials: false
       - name: Build and Test
         run: xcodebuild clean test -project DeltaCodec.xcodeproj -scheme DeltaCodec-tvOS -destination "${destination}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
     env:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           submodules: 'recursive'
           persist-credentials: false
@@ -27,7 +27,7 @@ jobs:
       matrix:
         destination: ['platform=iOS Simulator,OS=26.0.1,name=iPhone 17']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           submodules: 'recursive'
           persist-credentials: false
@@ -44,7 +44,7 @@ jobs:
       matrix:
         destination: ['platform=tvOS Simulator,OS=18.2,name=Apple TV']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           submodules: 'recursive'
           persist-credentials: false


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflow in this repo, addressing findings from a workflow security audit. Changes are split into three commits, one per finding type:

- Disable credential persistence on `actions/checkout` steps (`persist-credentials: false`) so the default `GITHUB_TOKEN` is not left in the local git config after checkout. The workflow doesn't push or otherwise re-use the token from the working copy.
- Scope each job's permissions explicitly: top-level `permissions: {}`, with each job granted only `contents: read` (the minimum needed for `actions/checkout`). None of these jobs push, comment, or write packages.
- Pin `actions/checkout` to a commit SHA (`ee0669bd…` = v2.7.0, with the tag preserved as a comment) so an upstream tag move can't silently change what runs in CI.

No behavioural changes intended — the workflow runs the same checks against the same inputs.
